### PR TITLE
Add `account export-private-key` command

### DIFF
--- a/autonity_cli/commands/account.py
+++ b/autonity_cli/commands/account.py
@@ -318,7 +318,7 @@ def reveal_private_key(
     """
 
     confirmation = input(
-        "WARNING! This command exposes an account's private key.\n"
+        "⚠️ WARNING! This command exposes an account's private key.\n"
         "Type 'yes' to continue: "
     )
     if confirmation.lower() != "yes":


### PR DESCRIPTION
To complement `import-private-key`, allow users to export the private key from a Geth keyfile as a hex-string in case an external tool requires it in this format.