### PR TITLE
Fix type hints in ERC20 contract binding

### DIFF
--- a/autonity_cli/erc20.py
+++ b/autonity_cli/erc20.py
@@ -4,7 +4,7 @@ import typing
 
 import eth_typing
 import web3
-from web3.contract import base_contract, contract
+from web3.contract import contract
 
 
 class ERC20:
@@ -30,12 +30,12 @@ class ERC20:
         )
 
     @property
-    def Approval(self) -> typing.Type[base_contract.BaseContractEvent]:
+    def Approval(self) -> contract.ContractEvent:
         """Binding for `event Approval` on the ERC20 contract."""
         return self._contract.events.Approval
 
     @property
-    def Transfer(self) -> typing.Type[base_contract.BaseContractEvent]:
+    def Transfer(self) -> contract.ContractEvent:
         """Binding for `event Transfer` on the ERC20 contract."""
         return self._contract.events.Transfer
 


### PR DESCRIPTION
Web3.py dependency has been updated to v7.6.0 (implicitly via autonity.py). This Web3.py release includes a fix[1] that changed the type of the dynamically generated properties of `contract.events`.

Fix the type hints in the ERC20 binding to resolve linter error.

[1]: https://web3py.readthedocs.io/en/stable/release_notes.html#bugfixes