### PR TITLE
Fix: Ad `0x` prefix to private key in `account reveal-private-key` output

### DIFF
--- a/autonity_cli/commands/account.py
+++ b/autonity_cli/commands/account.py
@@ -337,7 +337,7 @@ def reveal_private_key(
     except ValueError as e:
         raise ClickException(str(e))
 
-    print(key.hex())
+    print(Web3.to_hex(key))
 
 
 account_group.add_command(reveal_private_key)


### PR DESCRIPTION
Currently the output of `account reveal-private-key` only prints the digits of the private key without the `0x` prefix, which is not the standard hex-string format.