### PR TITLE
test: introduce pytest framework aligned with upstream 🧪

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,11 @@ allow-direct-references = true
 
 [tool.hatch.envs.default]
 description = "The standard dev, build, and test environment"
-dependencies = ["pyright"]
+dependencies = ["pyright", "pytest"]
 
 [tool.hatch.envs.default.scripts]
 test = ["unit-tests", "script-tests", "check-types"]
-unit-tests = "python -m unittest discover {args:tests}"
+unit-tests = "hatch run test:all"
 script-tests = [
   "rm -rf test_*",
   "hatch run ./scripts/test_contract",
@@ -63,6 +63,19 @@ script-tests = [
 ]
 # Keep in default env so it can be used from `github` and `local` envs.
 check-types = "pyright {args}"
+
+[tool.hatch.envs.test]
+description = "Run tests"
+dependencies = [
+  "pytest",
+  "pytest-cov",
+  "pytest-mock",
+  "responses",
+]
+
+[tool.hatch.envs.test.scripts]
+all = "pytest {args:tests}"
+cov = "pytest --cov=autonity_cli --cov-report=term-missing {args:tests}"
 
 [tool.hatch.envs.github]
 description = "Develop and build against autonity.py from Github"
@@ -95,6 +108,12 @@ format = [
   "black {args:.}",
   "ruff check --fix --select I {args:.}",
   "RUST_LOG=warn taplo fmt pyproject.toml",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+  "integration: requires live RPC endpoint or auth service",
 ]
 
 [tool.pyright]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared test fixtures."""
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner() -> Iterator[CliRunner]:
+    """CliRunner with isolated filesystem."""
+    runner_ = CliRunner()
+    with runner_.isolated_filesystem():
+        yield runner_
+
+
+@pytest.fixture
+def autrc(runner: CliRunner) -> Callable[..., Path]:
+    """Create a temporary .autrc file. Returns factory function."""
+
+    def _make_autrc(**fields: str) -> Path:
+        lines = ["[aut]\n"]
+        for k, v in fields.items():
+            lines.append(f"{k} = {v}\n")
+        path = Path(".autrc")
+        path.write_text("".join(lines))
+        return path
+
+    return _make_autrc

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@ Test util functions
 """
 
 from datetime import datetime, timezone
-from unittest import TestCase
 
+import pytest
 from click import ClickException
 from web3 import Web3
 
@@ -17,94 +17,57 @@ from autonity_cli.utils import (
 )
 
 
-class TestUtils(TestCase):
-    """
-    Test util functions
-    """
+def test_wei_parser() -> None:
+    """Test Wei parser."""
+    assert parse_wei_representation("1kwei") == AutonDenoms.KWEI_VALUE_IN_WEI
+    assert parse_wei_representation("1mwei") == AutonDenoms.MWEI_VALUE_IN_WEI
+    assert parse_wei_representation("1gwei") == AutonDenoms.GWEI_VALUE_IN_WEI
+    assert parse_wei_representation("1szabo") == AutonDenoms.SZABO_VALUE_IN_WEI
+    assert parse_wei_representation("1finney") == AutonDenoms.FINNEY_VALUE_IN_WEI
+    assert parse_wei_representation("1auton") == AutonDenoms.AUTON_VALUE_IN_WEI
+    assert parse_wei_representation("1aut") == AutonDenoms.AUTON_VALUE_IN_WEI
 
-    def test_wei_parser(self) -> None:
-        """
-        Test Wei parser
-        """
-        self.assertEqual(
-            AutonDenoms.KWEI_VALUE_IN_WEI, parse_wei_representation("1kwei")
-        )
-        self.assertEqual(
-            AutonDenoms.MWEI_VALUE_IN_WEI, parse_wei_representation("1mwei")
-        )
-        self.assertEqual(
-            AutonDenoms.GWEI_VALUE_IN_WEI, parse_wei_representation("1gwei")
-        )
-        self.assertEqual(
-            AutonDenoms.SZABO_VALUE_IN_WEI, parse_wei_representation("1szabo")
-        )
-        self.assertEqual(
-            AutonDenoms.FINNEY_VALUE_IN_WEI, parse_wei_representation("1finney")
-        )
-        self.assertEqual(
-            AutonDenoms.AUTON_VALUE_IN_WEI, parse_wei_representation("1auton")
-        )
-        self.assertEqual(
-            AutonDenoms.AUTON_VALUE_IN_WEI, parse_wei_representation("1aut")
-        )
+    # Fractional parts
+    assert parse_wei_representation("0.2kwei") == 200
+    assert parse_wei_representation("0.5auton") == AutonDenoms.FINNEY_VALUE_IN_WEI * 500
+    assert parse_wei_representation("0.2") == AutonDenoms.FINNEY_VALUE_IN_WEI * 200
 
-        # Fractional parts
-        self.assertEqual(200, parse_wei_representation("0.2kwei"))
-        self.assertEqual(
-            AutonDenoms.FINNEY_VALUE_IN_WEI * 500, parse_wei_representation("0.5auton")
-        )
-        self.assertEqual(
-            AutonDenoms.FINNEY_VALUE_IN_WEI * 500, parse_wei_representation("0.5auton")
-        )
-        self.assertEqual(
-            AutonDenoms.FINNEY_VALUE_IN_WEI * 200, parse_wei_representation("0.2")
-        )
 
-    def test_token_value_parser(self) -> None:
-        """
-        Test token value parser.
-        """
+def test_token_value_parser() -> None:
+    """Test token value parser."""
+    assert parse_token_value_representation("3.12345", 5) == 312345
+    assert parse_token_value_representation("3.12345", 4) == 31234
+    assert parse_token_value_representation("3.12345", 3) == 3123
+    assert parse_token_value_representation("3.12345", 2) == 312
+    assert parse_token_value_representation("3.12345", 1) == 31
+    assert parse_token_value_representation("3.12345", 0) == 3
 
-        self.assertEqual(312345, parse_token_value_representation("3.12345", 5))
-        self.assertEqual(31234, parse_token_value_representation("3.12345", 4))
-        self.assertEqual(3123, parse_token_value_representation("3.12345", 3))
-        self.assertEqual(312, parse_token_value_representation("3.12345", 2))
-        self.assertEqual(31, parse_token_value_representation("3.12345", 1))
-        self.assertEqual(3, parse_token_value_representation("3.12345", 0))
 
-    def test_parse_commission_rate(self) -> None:
-        """
-        Test parse_commission_rate.
-        """
+def test_parse_commission_rate() -> None:
+    """Test parse_commission_rate."""
+    assert parse_commission_rate("100") == 100
+    assert parse_commission_rate("0.9") == 9000
+    assert parse_commission_rate("90%") == 9000
+    assert parse_commission_rate("0.03") == 300
+    assert parse_commission_rate("0.0001") == 1
 
-        self.assertEqual(100, parse_commission_rate("100"))
-        self.assertEqual(9000, parse_commission_rate("0.9"))
-        self.assertEqual(9000, parse_commission_rate("90%"))
-        self.assertEqual(300, parse_commission_rate("0.03"))
-        self.assertEqual(1, parse_commission_rate("0.0001"))
+    with pytest.raises(ClickException):
+        parse_commission_rate("1")
+    with pytest.raises(ClickException):
+        parse_commission_rate("1.0")
+    with pytest.raises(ClickException):
+        parse_commission_rate("100.01")
 
-        with self.assertRaises(ClickException):
-            self.assertEqual(1, parse_commission_rate("1"))
-        with self.assertRaises(ClickException):
-            self.assertEqual(1, parse_commission_rate("1.0"))
-        with self.assertRaises(ClickException):
-            self.assertEqual(1, parse_commission_rate("100.01"))
 
-    def test_geth_keyfile_name(self) -> None:
-        """
-        Test geth keyfile name generation.
-        """
+def test_geth_keyfile_name() -> None:
+    """Test geth keyfile name generation."""
+    key_time = datetime.strptime(
+        "2022-02-07T17-19-56.517538", "%Y-%m-%dT%H-%M-%S.%f"
+    ).replace(tzinfo=timezone.utc)
 
-        # time = datetime.fromisoformat("2022-02-07T17:19:56.517538000Z")
-        key_time = datetime.strptime(
-            "2022-02-07T17-19-56.517538", "%Y-%m-%dT%H-%M-%S.%f"
-        ).replace(tzinfo=timezone.utc)
+    key_address = Web3.to_checksum_address("ca57f3b40b42fcce3c37b8d18adbca5260ca72ec")
 
-        key_address = Web3.to_checksum_address(
-            "ca57f3b40b42fcce3c37b8d18adbca5260ca72ec"
-        )
-
-        self.assertEqual(
-            "UTC--2022-02-07T17-19-56.517538000Z--ca57f3b40b42fcce3c37b8d18adbca5260ca72ec",
-            geth_keyfile_name(key_time, key_address),
-        )
+    assert geth_keyfile_name(key_time, key_address) == (
+        "UTC--2022-02-07T17-19-56.517538000Z--"
+        "ca57f3b40b42fcce3c37b8d18adbca5260ca72ec"
+    )


### PR DESCRIPTION
## Summary

- Port 4 existing unit tests from `unittest.TestCase` to plain pytest assertions (`assert`, `pytest.raises()`)
- Add dedicated `[tool.hatch.envs.test]` with pytest, pytest-cov, pytest-mock, and responses dependencies
- Add `[tool.pytest.ini_options]` config with `integration` marker for future use
- Create `tests/conftest.py` with `runner` (CliRunner) and `autrc` fixtures aligned with upstream's `standalone-tests` branch

## Test plan

- [x] `hatch run test:all` — pytest runs, 4 tests pass
- [x] `hatch run test:cov` — coverage report generated
- [x] `hatch run lint:check-code` — ruff + black pass
- [x] `hatch run pyright` — no new errors (1 pre-existing `device.py` trezor type error)
- [x] `hatch run unit-tests` — default env delegation to test env works

Refs #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
